### PR TITLE
.gitignore: ignore CLion (JetBrains IDE) related directories (#330)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ site/images/
 # Temp folders for local binary creation
 obj-x86_64-linux-gnu
 debian
+
+# Clion (JetBrains IDE related files and directories)
+.idea
+cmake-build-debug


### PR DESCRIPTION
Co-authored-by: Jan-FrederikSchmidt <jan-frederik.schmidt@yuanda-robotics.de>